### PR TITLE
Feature/schema completion

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,11 +9,13 @@ Parses Aeronautical Information Exchange Model (AIXM) xml data to python datacla
 ## Installation and usage
 
 After cloning this repository
+
 ```bash
 $ pip install .
 ```
 
 File *example.py*
+
 ```python
 from pprint import pprint
 import sys
@@ -26,21 +28,23 @@ if __name__ == '__main__':
         pprint(features)
 
 ```
-Function *parse()* parses xml from file. If *resolve_links* is true xlink:href referrences are
-replaced with the features i.e. dataclasses they refer to. Otherwise the *target* attribute on the XLink
-dataclass referrs to the feature.
 
+Function *parse()* parses xml from file. If *resolve_links* is true xlink:href references are
+replaced with the features i.e. dataclasses they refer to. Otherwise the *target* attribute on the XLink
+dataclass refers to the feature.
 
 The package can be executed directly. It dumps the AIXM data as json.
+
 ```bash
 $ python -m pyaixm aixm_input_file.xml
 ```
 
-
 Example aixm data file can be found in
-* https://github.com/aixm/donlon
-* https://aip.dfs.de/datasets/
-* https://github.com/volkerp/aixm
+
+* <https://github.com/aixm/donlon>
+* <https://aip.dfs.de/datasets>
+* <https://github.com/volkerp/aixm>
+* <https://github.com/ben-volant/aixm_procedure_example>
 
 
 

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -1701,7 +1701,7 @@ Procedure: &Procedure
   RNAV: CodeYesNoType
   availability: ProcedureAvailability
   airportHeliport: AirportHeliport
-  aircraftCharactertic: AircraftCharacteristic
+  aircraftCharacteristic: AircraftCharacteristic
   flightTransition: ProcedureTransition
   guidanceFacility:
     type: GuidanceService

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -887,8 +887,6 @@ TerminalSegmentPoint: #*SegmentPoint
   extendedServiceVolume: RadioFrequencyArea
   annotation: Note
   pointChoice: SignificantPoint
-  pointChoice_navaidSystem: SignificantPoint
-  pointChoice_fixDesignatedPoint: SignificantPoint
 
 VerticalStructure:
   name: TextNameType

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -1209,29 +1209,6 @@ ObstacleArea:
   obstacle: VerticalStructure
   reference: ObstacleAreaOrigin 
 
-VerticalStructure:
-  name: TextNameType
-  type: CodeVerticalStructureType
-  lighted: CodeYesNoType
-  markingICAOStandard: CodeYesNoType
-  group: CodeYesNoType
-  length: ValDistanceType
-  width: ValDistanceType
-  radius: ValDistanceType
-  lightingICAOStandard: CodeYesNoType
-  synchronisedLighting: CodeYesNoType
-  supportedGroundLight: GroundLightSystem
-  marker: MarkerBeacon
-  hostedNavaidEquipment: NavaidEquipment
-  hostedSpecialNavStation: SpecialNavigationStation
-  annotation: Note
-  hostedPassengerService: PassengerService
-  supportedService: Service
-  hostedOrganisation: OrganisationAuthority
-  lightingAvailability: VerticalStructureLightingStatus
-  hostedUnit: Unit
-  part: VerticalStructurePart
-
 VerticalStructureLightingStatus:
   <<: *PropertiesWithSchedule
   status: CodeStatusOperationsType 

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -1543,7 +1543,36 @@ SurveillanceGroundStation:
 ##  Approaches  ##
 ##################
 
+ProcedureAvailability:
+  status: CodeProcedureAvailabilityType
+  timeInterval: Timesheet
+  annotation: Note
+  specialDateAuthority: OrganisationAuthority
+
+Procedure: &Procedure
+  communicationFailureInstruction: TextInstructionType
+  instruction: TextInstructionType
+  designCriteria: CodeDesignStandardType
+  codingStandard: CodeProcedureCodingStandardType
+  flightChecked: CodeYesNoType
+  name: TextNameType
+  RNAV: CodeYesNoType
+  availability: ProcedureAvailability
+  airportHeliport: AirportHeliport
+  aircraftCharactertic: AircraftCharacteristic
+  flightTransition: ProcedureTransition
+  guidanceFacility: GuidanceService
+  annotation: Note
+  safeAltitude: SafeAltitudeArea
+
+FinalProfile:
+  altitude: ApproachAltitudeTable
+  distance: ApproachDistanceTable
+  timing: ApproachTimingTable
+  annotation: note
+
 InstrumentApproachProcedure:
+  <<: *Procedure
   approachPrefix: CodeApproachPrefixType 
   approachType: CodeApproachType 
   multipleIdentification: CodeUpperAlphaType 
@@ -1553,18 +1582,9 @@ InstrumentApproachProcedure:
   additionalEquipment: CodeApproachEquipmentAdditionalType 
   channelGNSS: ValChannelNumberType 
   WAASReliable: CodeYesNoType 
-  communicationFailureInstruction: TextInstructionType 
-  instruction: TextInstructionType 
-  designCriteria: CodeDesignStandardType 
-  codingStandard: CodeProcedureCodingStandardType 
-  flightChecked: CodeYesNoType 
-  name: TextNameType 
-  RNAV: CodeYesNoType 
-  airportHeliport: AirportHeliport
-  AircraftCharacteristic: AircraftCharacteristic
   landing: LandingTakeoffAreaCollection
   missedInstruction: MissedApproachGroup
-  flightTransition: ProcedureTransition
+  finalProfile: FinalProfile
 
 MissedApproachGroup:
   instruction: TextInstructionType
@@ -1629,3 +1649,56 @@ ProcedureTransition:
   instruction: TextInstructionType
   vectorHeading: ValBearingType
   seqNumberARINC: NoSequenceType
+
+SafeAltitudeArea:
+  location: AirportHeliport
+  safeAreaType: CodeSafeAltitudeType
+  centrePoint: 
+    type: SignificantPoint
+    choice:
+      - airportReferencePoint: AirportHeliport
+      - aimingPoint: TouchDownLiftOff
+      - runwayPoint: RunwayCentrelinePoint
+      - position: Point
+      - centrePoint_navaidSystem: Navaid
+      - centrePoint_fixDesignatedPoint: DesignatedPoint
+      - annotation: Note
+      - sector: SafeAltitudeSector
+
+SafeAltitudeSector:
+  bufferWidth: ValDistanceType
+  extent: Surface
+  annotation: Note
+  sectorDefinition: CircleSector
+  significantObstacle: Obstruction
+
+StandardInstrumentDeparture:
+  <<: *Procedure
+  designator: TextSIDSTARDesignatorType
+  contingencyRoute:  CodeYesNoType
+  takeoff: LandingTakeoffAreaCollection
+
+StandardInstrumentArrival:
+  <<: *Procedure
+  designator: TextSIDSTARDesignatorType
+  arrival: LandingTakeoffAreaCollection
+
+TerminalArrivalAreaSector:
+  flyByCode: CodeYesNoType
+  procedureTurnRequired: CodeYesNoType
+  altitudeDescription: CodeAltitudeUseType
+  extent: Surface
+  annotation: Note
+  sectorDefinition: CircleSector
+  significantObstacle: Obstruction
+
+TerminalArrivalArea:
+  arrivalAreaType: CodeTAAType
+  outerBufferWidth: ValDistanceType
+  lateralBufferWidth: ValDistanceType
+  buffer: Surface
+  IAF: SignificantPoint
+  IF: SignificantPoint
+  annotation: Note
+  approachRNAV: InstrumentApproachProcedure
+  sector: TerminalArrivalAreaSector

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -1629,8 +1629,34 @@ ApproachLeg: &ApproachLeg
 ArrivalFeederLeg: 
   <<: *ApproachLeg
 
+FASDataBlock:
+  horizontalAlarmLimit: ValAlarmLimitType
+  verticalAlarmLimit: ValAlarmLimitType
+  thresholdCourseWidth: ValDistanceType
+  lengthOffset: ValDistanceType
+  CRCRemainder: ValHexType
+  operationType: NoSequenceType
+  serviceProviderSBAS: NoSequenceType
+  approachPerformanceDesignator: NoSequenceType
+  routeIndicator: AlphaType
+  referencePathDataSelector: NoSequenceType
+  referencePathIdentifier: AlphanumericType
+  codeICAO: AlphanumericType
+
 FinalLeg:
   <<: *ApproachLeg
+  guidanceSystem: CodeFinalGuidanceType
+  landingSystemCategory: CodeApproachGuidanceType
+  minimumBaroVnavTemperature: ValTemperatureType
+  rnpDMEAuthorized: CodeYesNoType
+  courseOffsetAngle: ValBearingType
+  courseOffsetSide: CodeSideType
+  courseCentrelineDistance: ValDistanceType
+  courseOffsetDistance: ValDistanceType
+  courseCentrelineIntersect: CodeRelativePositionType
+  finalPathAlignmentPoint: SignificantPoint
+  visualDescentPoint: TerminalSegmentPoint
+  FASData: FASDataBlock
 
 InitialLeg:
   <<: *ApproachLeg
@@ -1640,6 +1666,29 @@ IntermediateLeg:
 
 MissedApproachLeg:
   <<: *ApproachLeg
+  type: CodeMissedApproachType
+  thresholdAfterMAPT: CodeYesNoType
+  heightMAPT: ValDistanceVerticalType
+  requiredNavigationPerformance: CodeRNPType
+
+DepartureArrivalCondition:
+  minimumEnrouteAltitude: ValDistanceVerticalType
+  minimumCrossingAtEnd: ValDistanceVerticalType
+  minimumCrossingAtEndReference: CodeVerticalReferenceType
+  maximumCrossingAtEnd: ValDistanceVerticalType
+  maximumCrossingAtEndReference: CodeVerticalReferenceType
+  engineType: AircraftCharacteristic
+  annotation: Note
+
+DepartureLeg:
+  <<: *SegmentLeg
+  requiredNavigationPerformance: CodeRNPType
+  minimumObstacleClearanceAltitude: ValDistanceVerticalType
+  condition: DepartureArrivalCondition
+
+ArrivalLeg:
+  <<: *SegmentLeg
+  requiredNavigationPerformance: CodeRNPType
 
 ProcedureTransition:
   annotation: Note

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -1846,7 +1846,7 @@ ArrivalLeg:
   requiredNavigationPerformance: CodeRNPType
 
 ProcedureTransitionLeg:
-  seqNumberArinc: NoSequenceType
+  seqNumberARINC: NoSequenceType
   annotation: Note
   theSegmentLeg: SegmentLeg
 

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -521,6 +521,9 @@ GuidanceLineMarking:
   markingICAOStandard: CodeYesNoType
   condition: CodeMarkingConditionType
 
+LandingTakeoffAreaCollection:
+  runway: Runway
+
 LightActivation:
   clicks: NoNumberType
   intensityLevel: CodeLightIntensityType
@@ -821,13 +824,17 @@ ContactInformation:
   address: PostalAddress
   phoneFax: TelephoneContact
 
-ElevatedPoint:
+Point: &Point
   pos: str
+  horizontalAccuracy: str
+  annotation: str
+
+ElevatedPoint:
+  <<: *Point
   elevation: str
   geoidUndulation: str
   verticalDatum: str
   verticalAccuracy: str
-  horizontalAccuracy: str
 
 ElevatedSurface:
   elevation: ValDistanceVerticalType
@@ -1021,6 +1028,8 @@ DesignatedPoint:
   designator: CodeDesignatedPointDesignatorType
   type: CodeDesignatedPointType
   name: TextNameType
+  location: Point
+  airportHeliport: AirportHeliport
 
 DME:
   <<: *NavaidEquipment
@@ -1321,10 +1330,6 @@ Service: &Service
   availability: ServiceOperationalStatus
   groundCommunication: ContactInformation
 
-CallsignDetail:
-  callSign: TextNameType
-  language: CodeLanguageType
-
 TrafficSeparationService: &TrafficSeparationService
   <<: *Service
   radarAssisted: CodeYesNoType
@@ -1357,7 +1362,7 @@ AirportClearanceService:
   <<: *AirportGroundService
   snowPlan: TextInstructionType
 
-AirportGroundService:
+AirportHeliportGroundService:
   <<: *Service
   airportHeliport: AirportHeliport
 
@@ -1521,3 +1526,56 @@ SecondarySurveillanceRadar:
 
 SurveillanceGroundStation:
   videoMap: CodeYesNoType
+
+##################
+##  Approaches  ##
+##################
+
+InstrumentApproachProcedure:
+  approachPrefix: CodeApproachPrefixType 
+  approachType: CodeApproachType 
+  multipleIdentification: CodeUpperAlphaType 
+  copterTrack: ValBearingType 
+  circlingIdentification: CodeUpperAlphaType 
+  courseReversalInstruction: TextInstructionType 
+  additionalEquipment: CodeApproachEquipmentAdditionalType 
+  channelGNSS: ValChannelNumberType 
+  WAASReliable: CodeYesNoType 
+  communicationFailureInstruction: TextInstructionType 
+  instruction: TextInstructionType 
+  designCriteria: CodeDesignStandardType 
+  codingStandard: CodeProcedureCodingStandardType 
+  flightChecked: CodeYesNoType 
+  name: TextNameType 
+  RNAV: CodeYesNoType 
+  airportHeliport: AirportHeliport
+  AircraftCharacteristic: AircraftCharacteristic
+  landing: LandingTakeoffAreaCollection
+  missedInstruction: MissedApproachGroup
+  flightTransition: ProcedureTransition
+
+MissedApproachGroup:
+  instruction: TextInstructionType
+
+
+SegmentLeg: &SegmentLeg
+  upperLimitAltitude: ValDistanceVerticalType
+  upperLimitReference: CodeVerticalReferenceType
+  lowerLimitAltitude: ValDistanceVerticalType
+  lowerLimitReference: CodeVerticalReferenceType
+
+InitialLeg:
+  <<: *SegmentLeg
+
+TransitionLeg:
+  <<: *SegmentLeg
+
+ProcedureTransition:
+  annotation: Note
+  theSegmentLeg: SegmentLeg
+  transitionId: CodeDesignatedPointDesignatorType
+  type: CodeProcedurePhaseType
+  instruction: TextInstructionType
+  vectorHeading: ValBearingType
+
+

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -1759,14 +1759,20 @@ ArrivalLeg:
   <<: *SegmentLeg
   requiredNavigationPerformance: CodeRNPType
 
-ProcedureTransition:
+ProcedureTransitionLeg:
+  seqNumberArinc: NoSequenceType
   annotation: Note
   theSegmentLeg: SegmentLeg
+
+ProcedureTransition:
   transitionId: CodeDesignatedPointDesignatorType
   type: CodeProcedurePhaseType
   instruction: TextInstructionType
   vectorHeading: ValBearingType
-  seqNumberARINC: NoSequenceType
+  trajectory: Curve
+  annotation: Note
+  departureRunwayTransition: LandingTakeoffAreaCollection
+  transitionLeg: ProcedureTransitionLeg
 
 SafeAltitudeArea:
   location: AirportHeliport

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -1597,20 +1597,23 @@ SegmentLeg: &SegmentLeg
   aircraftCategory: AircraftCharacteristic
   designSurface: ObstacleAssessmentArea
 
-InitialLeg:
+ApproachLeg: &ApproachLeg
   <<: *SegmentLeg
 
-IntermediateLeg:
-  <<: *SegmentLeg
-
-TransitionLeg:
-  <<: *SegmentLeg
-
-MissedApproachLeg:
-  <<: *SegmentLeg
+ArrivalFeederLeg: 
+  <<: *ApproachLeg
 
 FinalLeg:
-  <<: *SegmentLeg
+  <<: *ApproachLeg
+
+InitialLeg:
+  <<: *ApproachLeg
+
+IntermediateLeg:
+  <<: *ApproachLeg
+
+MissedApproachLeg:
+  <<: *ApproachLeg
 
 ProcedureTransition:
   annotation: Note

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -522,7 +522,7 @@ GuidanceLineMarking:
   condition: CodeMarkingConditionType
 
 LandingTakeoffAreaCollection:
-  runway: Runway
+  runway: RunwayDirection
 
 LightActivation:
   clicks: NoNumberType
@@ -1567,7 +1567,16 @@ SegmentLeg: &SegmentLeg
 InitialLeg:
   <<: *SegmentLeg
 
+IntermediateLeg:
+  <<: *SegmentLeg
+
 TransitionLeg:
+  <<: *SegmentLeg
+
+MissedApproachLeg:
+  <<: *SegmentLeg
+
+FinalLeg:
   <<: *SegmentLeg
 
 ProcedureTransition:
@@ -1577,5 +1586,3 @@ ProcedureTransition:
   type: CodeProcedurePhaseType
   instruction: TextInstructionType
   vectorHeading: ValBearingType
-
-

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -223,7 +223,11 @@ SegmentPoint: &SegmentPoint
   radarGuidance: CodeYesNoType
   facilityMakeup: PointReference
   extendedServiceVolume: RadioFrequencyArea
-  pointChoice: SignificantPoint
+  pointChoice:
+    type: SignificantPoint
+    choice:
+      - pointChoice_fixDesignatedPoint: DesignatedPoint
+      - pointChoice_navaidSystem: Navaid
 
 #########################
 ##  Aerial Refuelling  ##
@@ -886,7 +890,11 @@ TerminalSegmentPoint: #*SegmentPoint
   facilityMakeup: PointReference
   extendedServiceVolume: RadioFrequencyArea
   annotation: Note
-  pointChoice: SignificantPoint
+  pointChoice:
+    type: SignificantPoint
+    choice:
+      - pointChoice_fixDesignatedPoint: DesignatedPoint
+      - pointChoice_navaidSystem: Navaid
 
 VerticalStructure:
   name: TextNameType

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -228,6 +228,10 @@ SegmentPoint: &SegmentPoint
     choice:
       - pointChoice_fixDesignatedPoint: DesignatedPoint
       - pointChoice_navaidSystem: Navaid
+      - pointChoice_aimingPoint: TouchDownLiftOff
+      - pointChoice_runwayPoint: RunwayCentrelinePoint
+      - pointChoice_airportReferencePoint: AirportHeliport
+      - pointChoice_position: Point
 
 #########################
 ##  Aerial Refuelling  ##
@@ -825,6 +829,17 @@ AngleIndication:
   trueAngle: ValBearingType
   cardinalDirection: CodeCardinalDirectionType
   minimumReceptionAltitude: ValDistanceVerticalType
+  pointChoice:
+    type: SignificantPoint
+    choice:
+      - pointChoice_fixDesignatedPoint: DesignatedPoint
+      - pointChoice_navaidSystem: Navaid
+      - pointChoice_aimingPoint: TouchDownLiftOff
+      - pointChoice_runwayPoint: RunwayCentrelinePoint
+      - pointChoice_airportReferencePoint: AirportHeliport
+      - pointChoice_position: Point
+  annotation: Note
+  fix: DesignatedPoint
 
 AngleUse:
   alongCourseGuidance: CodeYesNoType
@@ -903,6 +918,10 @@ TerminalSegmentPoint: #*SegmentPoint
     choice:
       - pointChoice_fixDesignatedPoint: DesignatedPoint
       - pointChoice_navaidSystem: Navaid
+      - pointChoice_aimingPoint: TouchDownLiftOff
+      - pointChoice_runwayPoint: RunwayCentrelinePoint
+      - pointChoice_airportReferencePoint: AirportHeliport
+      - pointChoice_position: Point
 
 VerticalStructure:
   name: TextNameType
@@ -955,7 +974,12 @@ HoldingPattern:
   instruction: TextInstructionType
   nonStandardHolding: CodeYesNoType
   extent: Curve
-  outboundLegSpan: HoldingPatternLength
+  outboundLegSpan: 
+    type: HoldingPatternLength
+    choice:
+      - outboundLegSpan_endDistance: HoldingPatternDistance
+      - outboundLegSpan_endTime: HoldingPatternDuration
+      - outboundLegSpan_endPoint: SegmentPoint
   annotation: Note
   holdingPoint: SegmentPoint
 
@@ -1067,6 +1091,17 @@ DistanceIndication:
   distance: ValDistanceType
   minimumReceptionAltitude: ValDistanceVerticalType
   type: CodeDistanceIndicationType
+  pointChoice:
+    type: SignificantPoint
+    choice:
+      - pointChoice_fixDesignatedPoint: DesignatedPoint
+      - pointChoice_navaidSystem: Navaid
+      - pointChoice_aimingPoint: TouchDownLiftOff
+      - pointChoice_runwayPoint: RunwayCentrelinePoint
+      - pointChoice_airportReferencePoint: AirportHeliport
+      - pointChoice_position: Point
+  annotation: Note
+  fix: DesignatedPoint
 
 Elevation:
   <<: *NavaidEquipment
@@ -1163,7 +1198,15 @@ SignificantPointInAirspace:
   type: CodeAirspacePointRoleType
   relativeLocation: CodeAirspacePointPositionType
   containingAirspace: Airspace
-  location: SignificantPoint
+  location:
+    type: SignificantPoint
+    choice:
+      - location_fixDesignatedPoint: DesignatedPoint
+      - location_navaidSystem: Navaid
+      - location_aimingPoint: TouchDownLiftOff
+      - location_runwayPoint: RunwayCentrelinePoint
+      - location_airportReferencePoint: AirportHeliport
+      - location_position: Point
   annotation: Note
 
 SpecialNavigationStation:
@@ -1207,7 +1250,12 @@ ObstacleArea:
   surfaceExtent: Surface
   annotation: Note
   obstacle: VerticalStructure
-  reference: ObstacleAreaOrigin 
+  reference: 
+    type: ObstacleAreaOrigin 
+    choice:
+      - reference_ownerAirport: AirportHeliport
+      - reference_ownerRunway: RunwayDirection
+      - reference_ownerOrganisartion: OrganisationAuthority
 
 VerticalStructureLightingStatus:
   <<: *PropertiesWithSchedule
@@ -1279,7 +1327,15 @@ AirspaceBorderCrossing:
 
 ChangeOverPoint:
   distance: ValDistanceType
-  location: SignificantPoint
+  location:
+    type: SignificantPoint
+    choice:
+      - location_fixDesignatedPoint: DesignatedPoint
+      - location_navaidSystem: Navaid
+      - location_aimingPoint: TouchDownLiftOff
+      - location_runwayPoint: RunwayCentrelinePoint
+      - location_airportReferencePoint: AirportHeliport
+      - location_position: Point
   applicableRoutePortion: RoutePortion
 
 DirectFlight: &DirectFlight
@@ -1291,8 +1347,24 @@ DirectFlightClass:
 
 DirectFlightSegment:
   <<: *DirectFlight
-  end: SignificantPoint
-  start: SignificantPoint
+  end:
+    type: SignificantPoint
+    choice:
+      - end_fixDesignatedPoint: DesignatedPoint
+      - end_navaidSystem: Navaid
+      - end_aimingPoint: TouchDownLiftOff
+      - end_runwayPoint: RunwayCentrelinePoint
+      - end_airportReferencePoint: AirportHeliport
+      - end_position: Point
+  start:
+    type: SignificantPoint
+    choice:
+      - start_fixDesignatedPoint: DesignatedPoint
+      - start_navaidSystem: Navaid
+      - start_aimingPoint: TouchDownLiftOff
+      - start_runwayPoint: RunwayCentrelinePoint
+      - start_airportReferencePoint: AirportHeliport
+      - start_position: Point
 
 Route:
   designatorPrefix: CodeRouteDesignatorPrefixType
@@ -1322,9 +1394,33 @@ RouteDME:
   applicableRoutePortion: RoutePortion
 
 RoutePortion:
-  start: SignificantPoint
-  intermediatePoint: SignificantPoint
-  end: SignificantPoint
+  end:
+    type: SignificantPoint
+    choice:
+      - end_fixDesignatedPoint: DesignatedPoint
+      - end_navaidSystem: Navaid
+      - end_aimingPoint: TouchDownLiftOff
+      - end_runwayPoint: RunwayCentrelinePoint
+      - end_airportReferencePoint: AirportHeliport
+      - end_position: Point
+  start:
+    type: SignificantPoint
+    choice:
+      - start_fixDesignatedPoint: DesignatedPoint
+      - start_navaidSystem: Navaid
+      - start_aimingPoint: TouchDownLiftOff
+      - start_runwayPoint: RunwayCentrelinePoint
+      - start_airportReferencePoint: AirportHeliport
+      - start_position: P
+  intermediatePoint:
+    type: SignificantPoint
+    choice:
+      - intermediatePoint_fixDesignatedPoint: DesignatedPoint
+      - intermediatePoint_navaidSystem: Navaid
+      - intermediatePoint_aimingPoint: TouchDownLiftOff
+      - intermediatePoint_runwayPoint: RunwayCentrelinePoint
+      - intermediatePoint_airportReferencePoint: AirportHeliport
+      - intermediatePoint_position: P
   referencedRoute: Route
 
 RouteSegment:
@@ -1607,7 +1703,12 @@ Procedure: &Procedure
   airportHeliport: AirportHeliport
   aircraftCharactertic: AircraftCharacteristic
   flightTransition: ProcedureTransition
-  guidanceFacility: GuidanceService
+  guidanceFacility:
+    type: GuidanceService
+    choice:
+      - guidanceFacility_navaid: Navaid
+      - guidanceFacility_specialNavigationSystem: SpecialNavigationSystem
+      - guidanceFacility_radar: RadarSystem
   annotation: Note
   safeAltitude: SafeAltitudeArea
 
@@ -1700,7 +1801,15 @@ FinalLeg:
   courseCentrelineDistance: ValDistanceType
   courseOffsetDistance: ValDistanceType
   courseCentrelineIntersect: CodeRelativePositionType
-  finalPathAlignmentPoint: SignificantPoint
+  finalPathAlignmentPoint: 
+    type: SignificantPoint
+    choice:
+      - finalPathAlignmentPoint_fixDesignatedPoint: DesignatedPoint
+      - finalPathAlignmentPoint_navaidSystem: Navaid
+      - finalPathAlignmentPoint_aimingPoint: TouchDownLiftOff
+      - finalPathAlignmentPoint_runwayPoint: RunwayCentrelinePoint
+      - finalPathAlignmentPoint_airportReferencePoint: AirportHeliport
+      - finalPathAlignmentPoint_position: Point
   visualDescentPoint: TerminalSegmentPoint
   FASData: FASDataBlock
 
@@ -1757,14 +1866,14 @@ SafeAltitudeArea:
   centrePoint: 
     type: SignificantPoint
     choice:
-      - airportReferencePoint: AirportHeliport
-      - aimingPoint: TouchDownLiftOff
-      - runwayPoint: RunwayCentrelinePoint
-      - position: Point
+      - centrePoint_airportReferencePoint: AirportHeliport
+      - centrePoint_aimingPoint: TouchDownLiftOff
+      - centrePoint_runwayPoint: RunwayCentrelinePoint
+      - centrePoint_position: Point
       - centrePoint_navaidSystem: Navaid
       - centrePoint_fixDesignatedPoint: DesignatedPoint
-      - annotation: Note
-      - sector: SafeAltitudeSector
+  annotation: Note
+  sector: SafeAltitudeSector
 
 SafeAltitudeSector:
   bufferWidth: ValDistanceType

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -883,6 +883,12 @@ TerminalSegmentPoint: #*SegmentPoint
   flyOver: CodeYesNoType
   waypoint: CodeYesNoType
   radarGuidance: CodeYesNoType
+  facilityMakeup: PointReference
+  extendedServiceVolume: RadioFrequencyArea
+  annotation: Note
+  pointChoice: SignificantPoint
+  pointChoice_navaidSystem: SignificantPoint
+  pointChoice_fixDesignatedPoint: SignificantPoint
 
 VerticalStructure:
   name: TextNameType
@@ -1557,12 +1563,39 @@ InstrumentApproachProcedure:
 MissedApproachGroup:
   instruction: TextInstructionType
 
-
 SegmentLeg: &SegmentLeg
+  endConditionDesignator: CodeSegmentTerminationType
+  legPath: CodeTrajectoryType
+  legTypeARINC: CodeSegmentPathType
+  course: ValBearingType
+  courseType: CodeCourseType
+  courseDirection: CodeDirectionReferenceType
+  turnDirection: CodeDirectionTurnType
+  speedLimit: ValSpeedType
+  speedReference: CodeSpeedReferenceType
+  speedInterpretation: CodeAltitudeUseType
+  bankAngle: ValAngleType
+  length: ValDistanceType
+  duration: ValDurationType
+  procedureTurnRequired: CodeYesNoType
   upperLimitAltitude: ValDistanceVerticalType
   upperLimitReference: CodeVerticalReferenceType
   lowerLimitAltitude: ValDistanceVerticalType
   lowerLimitReference: CodeVerticalReferenceType
+  altitudeInterpretation: CodeAltitudeUseType
+  altitudeOverrideATC: ValDistanceVerticalType
+  altitudeOverrideReference: CodeVerticalReferenceType
+  verticalAngle: ValAngleType
+  trajectory: Curve
+  holding: HoldingPattern
+  angle: AngleIndication
+  distance: DistanceIndication
+  startPoint: TerminalSegmentPoint
+  arcCentre: TerminalSegmentPoint
+  endPoint: TerminalSegmentPoint
+  annotation: Note
+  aircraftCategory: AircraftCharacteristic
+  designSurface: ObstacleAssessmentArea
 
 InitialLeg:
   <<: *SegmentLeg
@@ -1586,3 +1619,4 @@ ProcedureTransition:
   type: CodeProcedurePhaseType
   instruction: TextInstructionType
   vectorHeading: ValBearingType
+  seqNumberARINC: NoSequenceType

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -823,7 +823,6 @@ ContactInformation:
 
 ElevatedPoint:
   pos: str
-  annotation: str
   elevation: str
   geoidUndulation: str
   verticalDatum: str
@@ -1022,8 +1021,6 @@ DesignatedPoint:
   designator: CodeDesignatedPointDesignatorType
   type: CodeDesignatedPointType
   name: TextNameType
-  location: Point
-  airportHeliport: AirportHeliport
 
 DME:
   <<: *NavaidEquipment

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -521,6 +521,9 @@ GuidanceLineMarking:
   markingICAOStandard: CodeYesNoType
   condition: CodeMarkingConditionType
 
+LandingTakeoffAreaCollection:
+  runway: Runway
+
 LightActivation:
   clicks: NoNumberType
   intensityLevel: CodeLightIntensityType
@@ -821,13 +824,17 @@ ContactInformation:
   address: PostalAddress
   phoneFax: TelephoneContact
 
-ElevatedPoint:
+Point: &Point
   pos: str
+  horizontalAccuracy: str
+  annotation: str
+
+ElevatedPoint:
+  <<: *Point
   elevation: str
   geoidUndulation: str
   verticalDatum: str
   verticalAccuracy: str
-  horizontalAccuracy: str
 
 ElevatedSurface:
   elevation: ValDistanceVerticalType
@@ -1021,6 +1028,8 @@ DesignatedPoint:
   designator: CodeDesignatedPointDesignatorType
   type: CodeDesignatedPointType
   name: TextNameType
+  location: Point
+  airportHeliport: AirportHeliport
 
 DME:
   <<: *NavaidEquipment
@@ -1321,6 +1330,10 @@ Service: &Service
   availability: ServiceOperationalStatus
   groundCommunication: ContactInformation
 
+CallsignDetail:
+  callSign: TextNameType
+  language: CodeLanguageType
+
 TrafficSeparationService: &TrafficSeparationService
   <<: *Service
   radarAssisted: CodeYesNoType
@@ -1517,11 +1530,3 @@ SecondarySurveillanceRadar:
 
 SurveillanceGroundStation:
   videoMap: CodeYesNoType
-
-##################
-##  Approaches  ##
-##################
-
-InstrumentApproachProcedure:
-  type: CodeInstrumentApproachProcedureType
-  name: TextNameType

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -1521,3 +1521,11 @@ SecondarySurveillanceRadar:
 
 SurveillanceGroundStation:
   videoMap: CodeYesNoType
+
+##################
+##  Approaches  ##
+##################
+
+InstrumentApproachProcedure:
+  type: CodeInstrumentApproachProcedureType
+  name: TextNameType

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -521,9 +521,6 @@ GuidanceLineMarking:
   markingICAOStandard: CodeYesNoType
   condition: CodeMarkingConditionType
 
-LandingTakeoffAreaCollection:
-  runway: Runway
-
 LightActivation:
   clicks: NoNumberType
   intensityLevel: CodeLightIntensityType
@@ -824,17 +821,14 @@ ContactInformation:
   address: PostalAddress
   phoneFax: TelephoneContact
 
-Point: &Point
-  pos: str
-  horizontalAccuracy: str
-  annotation: str
-
 ElevatedPoint:
-  <<: *Point
+  pos: str
+  annotation: str
   elevation: str
   geoidUndulation: str
   verticalDatum: str
   verticalAccuracy: str
+  horizontalAccuracy: str
 
 ElevatedSurface:
   elevation: ValDistanceVerticalType
@@ -1366,7 +1360,7 @@ AirportClearanceService:
   <<: *AirportGroundService
   snowPlan: TextInstructionType
 
-AirportHelipotGroundService:
+AirportGroundService:
   <<: *Service
   airportHeliport: AirportHeliport
 

--- a/pyaixm/aixm_schema.yaml
+++ b/pyaixm/aixm_schema.yaml
@@ -1321,10 +1321,6 @@ Service: &Service
   availability: ServiceOperationalStatus
   groundCommunication: ContactInformation
 
-CallsignDetail:
-  callSign: TextNameType
-  language: CodeLanguageType
-
 TrafficSeparationService: &TrafficSeparationService
   <<: *Service
   radarAssisted: CodeYesNoType
@@ -1357,7 +1353,7 @@ AirportClearanceService:
   <<: *AirportGroundService
   snowPlan: TextInstructionType
 
-AirportGroundService:
+AirportHelipotGroundService:
   <<: *Service
   airportHeliport: AirportHeliport
 

--- a/pyaixm/aixm_types.py
+++ b/pyaixm/aixm_types.py
@@ -76,7 +76,7 @@ class GMLArcByCenterPoint:
     @classmethod
     def parse(cls, elm):
         o = cls()
-        o.pos = cls._parse_poslist(elm.find(GML + 'pos').text)
+        o.pos = cls._parse_poslist(elm.find(".//" + GML + 'pos').text)
         o.radius = float(elm.find(GML + 'radius').text)
         o.radius_uom = elm.find(GML + 'radius').get('uom')
         if elm.find(GML + 'startAngle') is not None:

--- a/pyaixm/parse_aixm.py
+++ b/pyaixm/parse_aixm.py
@@ -11,15 +11,30 @@ def replace_xlinks(features: list):
     "Replaces XLink references on all features with the referenced object"
     for feature in features:
         if isinstance(feature, aixm_types.Feature):
-            for field in fields(feature):
-                attr = getattr(feature, field.name)
-                if isinstance(attr, list):
-                    repl = [a.target if isinstance(a, aixm_types.XLink) and a.target is not None else a for a in attr]
-                    setattr(feature, field.name, repl)
-                elif isinstance(attr, aixm_types.XLink):
-                    if attr.target is not None:
-                        setattr(feature, field.name, attr.target)
+            replace_xlinks_r(feature, path=[feature.gmlid])
 
+
+def replace_xlinks_r(feature: aixm_types.Feature, path: list = []):
+    new_path = path
+    for field in fields(feature):
+        if field.name == "parent":
+            continue
+        attr = getattr(feature, field.name)
+        if isinstance(attr, list):
+            for i, a in enumerate(attr):
+                if isinstance(a, aixm_types.Feature):
+                   replace_xlinks_r(a, path=new_path + [a.gmlid])
+                if isinstance(a, aixm_types.XLink):
+                    if a.target is not None:
+                        attr[i] = a.target
+        if isinstance(attr, aixm_types.Feature):
+            if attr.gmlid in path:
+                continue
+            new_path.append(attr.gmlid)
+            replace_xlinks_r(attr, path=new_path)
+        if isinstance(attr, aixm_types.XLink):
+            if attr.target is not None:
+                setattr(feature, field.name, attr.target)
 
 def parse(files: list[str], resolve_xlinks = False) -> list:
     l = []

--- a/pyaixm/parse_aixm.py
+++ b/pyaixm/parse_aixm.py
@@ -11,7 +11,7 @@ def replace_xlinks(features: list):
     "Replaces XLink references on all features with the referenced object"
     for feature in features:
         if isinstance(feature, aixm_types.Feature):
-            replace_xlinks_r(feature, path=[feature.gmlid])
+            replace_xlinks_r(feature, path=[feature.identifier])
 
 
 def replace_xlinks_r(feature: aixm_types.Feature, path: list = []):
@@ -23,14 +23,14 @@ def replace_xlinks_r(feature: aixm_types.Feature, path: list = []):
         if isinstance(attr, list):
             for i, a in enumerate(attr):
                 if isinstance(a, aixm_types.Feature):
-                   replace_xlinks_r(a, path=new_path + [a.gmlid])
+                   replace_xlinks_r(a, path=new_path + [a.identifier])
                 if isinstance(a, aixm_types.XLink):
                     if a.target is not None:
                         attr[i] = a.target
         if isinstance(attr, aixm_types.Feature):
-            if attr.gmlid in path:
+            if attr.identifier in path:
                 continue
-            new_path.append(attr.gmlid)
+            new_path.append(attr.identifier)
             replace_xlinks_r(attr, path=new_path)
         if isinstance(attr, aixm_types.XLink):
             if attr.target is not None:

--- a/pyaixm/parse_aixm.py
+++ b/pyaixm/parse_aixm.py
@@ -19,30 +19,6 @@ def replace_xlinks(features: list):
                 elif isinstance(attr, aixm_types.XLink):
                     if attr.target is not None:
                         setattr(feature, field.name, attr.target)
-            replace_xlinks_r(feature, path=[feature.gmlid])
-
-
-def replace_xlinks_r(feature: aixm_types.Feature, path: list = []):
-    new_path = path
-    for field in fields(feature):
-        if field.name == "parent":
-            continue
-        attr = getattr(feature, field.name)
-        if isinstance(attr, list):
-            for i, a in enumerate(attr):
-                if isinstance(a, aixm_types.Feature):
-                   replace_xlinks_r(a, path=new_path + [a.gmlid])
-                if isinstance(a, aixm_types.XLink):
-                    if a.target is not None:
-                        attr[i] = a.target
-        if isinstance(attr, aixm_types.Feature):
-            if attr.gmlid in path:
-                continue
-            new_path.append(attr.gmlid)
-            replace_xlinks_r(attr, path=new_path)
-        if isinstance(attr, aixm_types.XLink):
-            if attr.target is not None:
-                setattr(feature, field.name, attr.target)
 
 
 def parse(files: list[str], resolve_xlinks = False) -> list:
@@ -56,22 +32,6 @@ def parse(files: list[str], resolve_xlinks = False) -> list:
         except etree.XMLSyntaxError as e:
             print(f"Error parsing file {f}: {e}")
             continue
-        for action, elem in context:
-            if action == 'end' and elem.tag in ['{http://www.aixm.aero/schema/5.1.1/message}hasMember', '{http://www.aixm.aero/schema/5.1/message}hasMember']:
-                feature = aixm_types.parse_feature(elem[0])  # first child of 'hasMember' is aixm feature
-                l.append(feature)
-def parse(f: typing.IO | list[typing.IO], resolve_xlinks = False) -> list:
-    l = []
-    if isinstance(f, list):
-        for g in f:
-            context = etree.iterparse(g)
-            for action, elem in context:
-                if action == 'end' and elem.tag in ['{http://www.aixm.aero/schema/5.1.1/message}hasMember', '{http://www.aixm.aero/schema/5.1/message}hasMember']:
-                    feature = aixm_types.parse_feature(elem[0])  # first child of 'hasMember' is aixm feature
-                    l.append(feature)
-
-    else:
-        context = etree.iterparse(f)
         for action, elem in context:
             if action == 'end' and elem.tag in ['{http://www.aixm.aero/schema/5.1.1/message}hasMember', '{http://www.aixm.aero/schema/5.1/message}hasMember']:
                 feature = aixm_types.parse_feature(elem[0])  # first child of 'hasMember' is aixm feature

--- a/pyaixm/parse_aixm.py
+++ b/pyaixm/parse_aixm.py
@@ -11,7 +11,7 @@ def replace_xlinks(features: list):
     "Replaces XLink references on all features with the referenced object"
     for feature in features:
         if isinstance(feature, aixm_types.Feature):
-            replace_xlinks_r(feature)
+            replace_xlinks_r(feature, path=[feature.gmlid])
 
 
 def replace_xlinks_r(feature: aixm_types.Feature, path: list = []):
@@ -21,14 +21,17 @@ def replace_xlinks_r(feature: aixm_types.Feature, path: list = []):
             continue
         attr = getattr(feature, field.name)
         if isinstance(attr, list):
-            for a in attr:
+            for i, a in enumerate(attr):
                 if isinstance(a, aixm_types.Feature):
                    replace_xlinks_r(a, path=new_path + [a.gmlid])
+                if isinstance(a, aixm_types.XLink):
+                    if a.target is not None:
+                        attr[i] = a.target
         if isinstance(attr, aixm_types.Feature):
             if attr.gmlid in path:
                 continue
             new_path.append(attr.gmlid)
-            replace_xlinks_r(feature, path=new_path)
+            replace_xlinks_r(attr, path=new_path)
         if isinstance(attr, aixm_types.XLink):
             if attr.target is not None:
                 setattr(feature, field.name, attr.target)

--- a/pyaixm/parse_aixm.py
+++ b/pyaixm/parse_aixm.py
@@ -18,13 +18,22 @@ def replace_xlinks(features: list):
                         setattr(feature, field.name, attr.target)
 
 
-def parse(f: typing.IO, resolve_xlinks = False) -> list:
-    context = etree.iterparse(f)
+def parse(f: typing.IO | list[typing.IO], resolve_xlinks = False) -> list:
     l = []
-    for action, elem in context:
-        if action == 'end' and elem.tag in ['{http://www.aixm.aero/schema/5.1.1/message}hasMember', '{http://www.aixm.aero/schema/5.1/message}hasMember']:
-            feature = aixm_types.parse_feature(elem[0])  # first child of 'hasMember' is aixm feature
-            l.append(feature)
+    if isinstance(f, list):
+        for g in f:
+            context = etree.iterparse(g)
+            for action, elem in context:
+                if action == 'end' and elem.tag in ['{http://www.aixm.aero/schema/5.1.1/message}hasMember', '{http://www.aixm.aero/schema/5.1/message}hasMember']:
+                    feature = aixm_types.parse_feature(elem[0])  # first child of 'hasMember' is aixm feature
+                    l.append(feature)
+
+    else:
+        context = etree.iterparse(f)
+        for action, elem in context:
+            if action == 'end' and elem.tag in ['{http://www.aixm.aero/schema/5.1.1/message}hasMember', '{http://www.aixm.aero/schema/5.1/message}hasMember']:
+                feature = aixm_types.parse_feature(elem[0])  # first child of 'hasMember' is aixm feature
+                l.append(feature)
 
     aixm_types.XLink.resolve()
 

--- a/pyaixm/parse_aixm.py
+++ b/pyaixm/parse_aixm.py
@@ -16,9 +16,7 @@ def replace_xlinks(features: list):
 
 def replace_xlinks_r(feature: aixm_types.Feature, path: list = []):
     new_path = path
-    print(new_path)
     for field in fields(feature):
-        print(field.name)
         if field.name == "parent":
             continue
         attr = getattr(feature, field.name)

--- a/pyaixm/parse_aixm.py
+++ b/pyaixm/parse_aixm.py
@@ -11,11 +11,29 @@ def replace_xlinks(features: list):
     "Replaces XLink references on all features with the referenced object"
     for feature in features:
         if isinstance(feature, aixm_types.Feature):
-            for field in fields(feature):
-                attr = getattr(feature, field.name)
-                if isinstance(attr, aixm_types.XLink):
-                    if attr.target is not None:
-                        setattr(feature, field.name, attr.target)
+            replace_xlinks_r(feature)
+
+
+def replace_xlinks_r(feature: aixm_types.Feature, path: list = []):
+    new_path = path
+    print(new_path)
+    for field in fields(feature):
+        print(field.name)
+        if field.name == "parent":
+            continue
+        attr = getattr(feature, field.name)
+        if isinstance(attr, list):
+            for a in attr:
+                if isinstance(a, aixm_types.Feature):
+                   replace_xlinks_r(a, path=new_path + [a.gmlid])
+        if isinstance(attr, aixm_types.Feature):
+            if attr.gmlid in path:
+                continue
+            new_path.append(attr.gmlid)
+            replace_xlinks_r(feature, path=new_path)
+        if isinstance(attr, aixm_types.XLink):
+            if attr.target is not None:
+                setattr(feature, field.name, attr.target)
 
 
 def parse(f: typing.IO | list[typing.IO], resolve_xlinks = False) -> list:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyaixm
-version = 0.0.2
+version = 0.0.3
 author = volkerp
 description = Parse AIXM data to python objects
 url = https://github.com/volkerp/pyaixm


### PR DESCRIPTION
This PR does three things:
i) In the last PR you merged (my thanks for that) you commented that the XLink replacement did not need to be recursive. I have now uploaded an example file here https://github.com/ben-volant/aixm_procedure_example demonstrating why this does need to be the case - the XLinks in the kinds of files I've been working with are deeply nested. This PR includes a slightly neater implementation of the recursive XLink replacement.
ii) Adds more of the AIXM 5.1 schema to the YAML file concerning procedures (e.g. SIDs, STARs). The example AIXM file above includes examples of these.
iii) Changes the way that pointChoice / significantPoint fields are reflected in the schema and adds a separate parsing handler to support this. This is intended to make it easier to work with e.g. terminal_segement_point.point_choice elements - regardless of how what kind of point they are their attributes can be accessed in the same way by the same name. Again, in the example AIXM file there are some motivating examples for this.

Happy to discuss / refine any of these if you have feedback. Many thanks.